### PR TITLE
Guard against overflow in fractional computations

### DIFF
--- a/felab/energy.py
+++ b/felab/energy.py
@@ -151,8 +151,22 @@ def inner_energy(
     # Интегрируем по квадратуре
     Du_x = Du(x)
     Dv_x = Dv(x)
-    term_energy = float(np.dot(w, Du_x * Dv_x))
-    term_mass = float(np.dot(w, a(x) * u_fun(x) * v_fun(x)))
+    with np.errstate(over="ignore", invalid="ignore"):
+        energy_vec = Du_x * Dv_x
+    if not np.all(np.isfinite(energy_vec)):
+        raise FloatingPointError(
+            "overflow in energy integrand; check fractional derivatives"
+        )
+
+    with np.errstate(over="ignore", invalid="ignore"):
+        mass_vec = a(x) * u_fun(x) * v_fun(x)
+    if not np.all(np.isfinite(mass_vec)):
+        raise FloatingPointError(
+            "overflow in mass integrand; check functions or coefficient"
+        )
+
+    term_energy = float(np.dot(w, energy_vec))
+    term_mass = float(np.dot(w, mass_vec))
     return (eps ** alpha) * term_energy + term_mass
 
 


### PR DESCRIPTION
## Summary
- add overflow-safe division in Caputo product integration
- validate energy/mass integrands and raise descriptive errors when overflow occurs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898e9d31d3c8328a2fad2d3464d95db