### PR TITLE
Handle complex values in phi0 evaluation

### DIFF
--- a/felab/atom.py
+++ b/felab/atom.py
@@ -73,10 +73,13 @@ class Phi0:
         """
         Возвращает φ₀(x;ε) = E_α(lam * x^α). Сохраняет действительность для x≥0.
         """
-        xv = np.asarray(x, dtype=float)
+        xv = np.asarray(np.real_if_close(x, tol=1000), dtype=float)
         # Для x=0: E_α(0)=1
         z = self.lam * np.power(np.clip(xv, 0.0, np.inf), self.alpha, where=(xv >= 0), out=np.zeros_like(xv))
-        val = _Ealpha(self.alpha, z)
+        # Switch to asymptotics for moderately large negative arguments
+        val = _Ealpha(self.alpha, z, z_switch=5.0)
+        # _Ealpha может дать численно мнимую часть ~1e-16; убираем её безопасно
+        val = np.real_if_close(val, tol=1000)
         # _Ealpha возвращает ndarray того же shape; гарантируем float для скаляра
         if np.isscalar(x):
             return float(val)  # type: ignore


### PR DESCRIPTION
## Summary
- ensure Phi0.__call__ drops negligible imaginary parts and uses asymptotic branch for large negative arguments

## Testing
- `python -m pytest`
- `python -m felab.atom` *(fails: AssertionError: Mismatch in D_C^α φ0 (rel=1))*

------
https://chatgpt.com/codex/tasks/task_e_6898e9bf54748328a6361b04ea33dda6